### PR TITLE
Patch various clippy security concerns

### DIFF
--- a/src/api_utils.rs
+++ b/src/api_utils.rs
@@ -4,5 +4,5 @@ use std::error::Error;
 pub fn create_api_instance() -> Result<RadioBrowserAPI, Box<dyn Error>> {
     //create api client instance here and pass through to relevent functions
     //really just to prevent creating too many clients and the server responding with a 429 error
-    Ok(RadioBrowserAPI::new()?)
+    RadioBrowserAPI::new()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,18 +61,18 @@ impl Default for StationConfigCache {
     }
 }
 pub trait ConfigCycle{
-    fn update(&mut self, incoming: &Vec<ApiStationShort>);
+    fn update(&mut self, incoming: &[ApiStationShort]);
     fn save(&self);
 }
 
 // -> Result<StationConfigCache, Box<dyn std::error::Error>> 
 impl ConfigCycle for StationConfigCache{
-    fn update(&mut self,incoming: &Vec<ApiStationShort>){
+    fn update(&mut self,incoming: &[ApiStationShort]){
         self.recents = update_recents(500, &mut self.recents, incoming);
     }
     fn save(&self){
         let config_path = Path::new(CONFIG_NAME);
-        let write_result = config_write(&config_path, &self);
+        let write_result = config_write(config_path, self);
         if let Err(e) = write_result {
             println!("Failed to write file: {}", e);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,9 +73,8 @@ impl ConfigCycle for StationConfigCache{
     fn save(&self){
         let config_path = Path::new(CONFIG_NAME);
         let write_result = config_write(&config_path, &self);
-        match write_result {
-            Err(e) => println!("Failed to write file: {}", e),
-            Ok(_) => (),
+        if let Err(e) = write_result {
+            println!("Failed to write file: {}", e);
         }
     }
 
@@ -90,8 +89,8 @@ Private Functions
 fn default_preset_return() -> Result<Vec<ApiStationShort>, Box<dyn std::error::Error>> {
     match create_api_instance() {
         Ok(tmp_api) => {
-            let api_ref = &tmp_api;
-            let defaults = &get_presets(&api_ref, &DEFAULT_PRESETS)?;
+
+            let defaults = &get_presets(&tmp_api, &DEFAULT_PRESETS)?;
             let station_list = convert_station_2_short
                 (
                     defaults, 
@@ -128,7 +127,7 @@ fn config_write(config_path: &Path, config: &StationConfigCache) -> Result<(), B
     
 }
 
-fn update_recents(limit: usize, cache: &mut Vec<ApiStationShort>, addition: &Vec<ApiStationShort>)-> Vec<ApiStationShort>{
+fn update_recents(limit: usize, cache: &mut Vec<ApiStationShort>, addition: &[ApiStationShort])-> Vec<ApiStationShort>{
     let combined_len = cache.len() + addition.len();
     if combined_len > limit{
         print!("removing first recents");
@@ -161,10 +160,9 @@ pub fn load_or_initialize() -> Result<StationConfigCache, Box<dyn std::error::Er
 
         let config = StationConfigCache::default();
         
-        let write_result = config_write(&config_path, &config);
-        match write_result {
-            Err(e) => println!("Failed to write file: {}", e),
-            Ok(_) => (),
+        let write_result = config_write(config_path, &config);
+        if let Err(e) = write_result {
+            println!("Failed to write file: {}", e);
         }
 
         Ok(config)

--- a/src/playing_traits.rs
+++ b/src/playing_traits.rs
@@ -17,10 +17,12 @@ impl Play for ApiStationShort {
         //mpv player function, accepts
         println!("Playing station: {}", self.station_name);
         println!("URL: {}", self.station_url);
-        let _ = Command::new("mpv")
+        let mut instance = Command::new("mpv")
             .arg(self.station_url.clone())
             .spawn()
             .expect("Failed to spawn mpv process");
+        
+        wait_for_child(&mut instance)?;
         Ok(()) 
     }
 }
@@ -31,10 +33,12 @@ impl Play for ApiStation {
         println!("Playing station: {}", self.name);
         println!("URL: {}", self.url);
 
-        let _ = Command::new("mpv")
+        let mut instance = Command::new("mpv")
             .arg(self.url.clone())
             .spawn()
             .expect("Failed to spawn mpv process");
+
+        wait_for_child(&mut instance)?;
         Ok(())
     }
 }
@@ -95,5 +99,15 @@ impl Selecting for Vec<ApiStation> {
                 Ok(())
             }
         }
+    }
+}
+
+fn wait_for_child(child: &mut std::process::Child) -> Result<std::process::ExitStatus, Box<dyn Error>> {
+    let status = child.wait()?;
+    
+    if status.success() {
+        Ok(status)
+    } else {
+        Err(format!("Child process exited with status: {}", status).into())
     }
 }


### PR DESCRIPTION
prevent memory leak process by waiting in playing_traits
replaced matches with if let & add slice to update_recents not a full vector in config.rs 
removed needless ? in api_utils undr create_api_instance